### PR TITLE
:bug: fix double free tlsSocket

### DIFF
--- a/lib60870-C/src/iec60870/cs104/cs104_connection.c
+++ b/lib60870-C/src/iec60870/cs104/cs104_connection.c
@@ -1021,8 +1021,10 @@ handleConnection(void* parameter)
         }
 
     #if (CONFIG_CS104_SUPPORT_TLS == 1)
-        if (self->tlsSocket)
+        if (self->tlsSocket){
             TLSSocket_close(self->tlsSocket);
+	    self->tlsSocket = NULL;
+	}
     #endif
 
         Socket_destroy(self->socket);


### PR DESCRIPTION
This PR fixes a double free of tlsSocket in a cs104 connection.

Reproduce double free:
- successfully establish a connection (self->tlsSocket is set)
- shut down the slave -> connection is closed and self->tlsSocket is freed
- try to reconnect from the client side (socket connect fails, self->tlsSocket untouched, but freed again)

This fix simple set tlsSocket to NULL once freed.