### PR TITLE
On OS X, there is no need to link rt

### DIFF
--- a/lib60870-C/src/CMakeLists.txt
+++ b/lib60870-C/src/CMakeLists.txt
@@ -149,11 +149,18 @@ GENERATE_EXPORT_HEADER(lib60870-shared
 add_library (lib60870 STATIC ${library_SRCS})
 
 IF(UNIX)
-    target_link_libraries (lib60870
-        -lpthread
-        -lm
-        -lrt
-    )
+    IF(APPLE)
+        target_link_libraries (lib60870
+            -lpthread
+            -lm
+        )
+    ELSE()
+        target_link_libraries (lib60870
+            -lpthread
+            -lm
+            -lrt
+        )
+    ENDIF(APPLE)
 
   configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/lib60870.pc.in


### PR DESCRIPTION
I was trying to build the `c104` Python library (https://iec104-python.readthedocs.io/latest/python/index.html) for OS X and the build was failing. The reason is that on OS X, the `rt` library apparently does not exist and is not needed.